### PR TITLE
Fix error: Class 'Request' not found

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,6 +20,8 @@
  * @link            http://xoops.org XOOPS
  */
 
+use Xmf\Request;
+
 require_once __DIR__ . '/header.php';
 $xoopsOption                  = (!isset($xoopsOption)) ? array() : $xoopsOption;
 $xoopsOption['template_main'] = 'randomquote_index.tpl';


### PR DESCRIPTION
An error occurred when we using this module under Xoops 2.5.10: Class 'Request' not found.
It can be fixed it by adding ```use Xmf\Request;``` in index.php.
I'm not sure if the fix is a correct way or not, so open a pull request to deal with it.